### PR TITLE
Remove touch event listeners to prevent errors in SetPointerAbsoluteP…

### DIFF
--- a/src/Runtime/Scripts/cshtml5.js
+++ b/src/Runtime/Scripts/cshtml5.js
@@ -450,11 +450,11 @@ document._attachEventListeners = function (element, handler, isFocusable) {
     store.isFocusable = isFocusable;
 
     view.addEventListener('mousedown', store['mousedown'] = bubblingEventHandler);
-    view.addEventListener('touchstart', store['touchstart'] = bubblingEventHandler, { passive: true });
+    //view.addEventListener('touchstart', store['touchstart'] = bubblingEventHandler, { passive: true });
     view.addEventListener('mouseup', store['mouseup'] = bubblingEventHandler);
-    view.addEventListener('touchend', store['touchend'] = bubblingEventHandler);
+    //view.addEventListener('touchend', store['touchend'] = bubblingEventHandler);
     view.addEventListener('mousemove', store['mousemove'] = bubblingEventHandler);
-    view.addEventListener('touchmove', store['touchmove'] = bubblingEventHandler, { passive: true });
+    //view.addEventListener('touchmove', store['touchmove'] = bubblingEventHandler, { passive: true });
     view.addEventListener('wheel', store['wheel'] = bubblingEventHandler, { passive: true });
     view.addEventListener('mouseenter', store['mouseenter'] = handler);
     view.addEventListener('mouseleave', store['mouseleave'] = handler);
@@ -474,11 +474,11 @@ document._removeEventListeners = function (element) {
 
     const store = view._eventsStore;
     view.removeEventListener('mousedown', store['mousedown']);
-    view.removeEventListener('touchstart', store['touchstart']);
+    //view.removeEventListener('touchstart', store['touchstart']);
     view.removeEventListener('mouseup', store['mouseup']);
-    view.removeEventListener('touchend', store['touchend']);
+    //view.removeEventListener('touchend', store['touchend']);
     view.removeEventListener('mousemove', store['mousemove']);
-    view.removeEventListener('touchmove', store['touchmove']);
+    //view.removeEventListener('touchmove', store['touchmove']);
     view.removeEventListener('wheel', store['wheel']);
     view.removeEventListener('mouseenter', store['mouseenter']);
     view.removeEventListener('mouseleave', store['mouseleave']);


### PR DESCRIPTION
…osition on touch devices

I found only one issue that dragging is not working in touch mode (including dragging the scrollbar thumb).


Here is the exception

`DEBUG: OnCallBack: OnCallBackFromJavascript: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.FormatException: The input string 'undefined' was not in a correct format.
   at System.Number.ThrowOverflowOrFormatException(ParsingStatus status, ReadOnlySpan`1 value, TypeCode type)
   at System.Number.ParseDouble(ReadOnlySpan`1 value, NumberStyles styles, NumberFormatInfo info)
   at System.Double.Parse(String s, IFormatProvider provider)
   at System.Windows.Input.MouseEventArgs.SetPointerAbsolutePosition(Object jsEventArg, Window window)
   at System.Windows.Input.MouseEventArgs.FillEventArgs(UIElement element, Object jsEventArg)
   at System.Windows.UIElement.ProcessMouseButtonEvent(Object jsEventArg, RoutedEvent routedEvent, Boolean refreshClickCount)
   at System.Windows.UIElement.ProcessOnMouseDown(Object jsEventArg)
   at System.Windows.UIElement.NativeEventCallback(UIElement mouseTarget, UIElement keyboardTarget, Object jsEventArg)
   at OpenSilver.Internal.NativeEventsManager.NativeEventCallback(Object jsEventArg)
   at OpenSilver.Internal.NativeEventsManager.<.ctor>b__4_0(Object jsEventArg)
   at System.Reflection.MethodInvoker.InterpretedInvoke(Object obj, Span`1 args, BindingFlags invokeAttr)
   --- End of inner exception stack trace ---
at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters)
   at System.Delegate.DynamicInvokeImpl(Object[] args)
   at System.MulticastDelegate.DynamicInvokeImpl(Object[] args)
   at System.Delegate.DynamicInvoke(Object[] args)
   at CSHTML5.Internal.OnCallBackImpl.DelegateDynamicInvoke(Delegate d, Object[] args)
   at CSHTML5.Internal.OnCallBackImpl.CallMethod[Object[]](Int32 callbackId, String idWhereCallbackArgsAreStored, Func`6 makeArguments, Object[] callbackArgs)
   at CSHTML5.Internal.OnCallBackImpl.<>c__DisplayClass8_0`1[[System.Object[], System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].<OnCallbackFromJavaScript>b__1()
   DEBUG: OnCallBack: OnCallBackFromJavascript: System.Reflection.TargetInvocationException: Exception has been thrown by the target of an invocation.
 ---> System.FormatException: The input string 'undefined' was not in a correct format.
   at System.Number.ThrowOverflowOrFormatException(ParsingStatus status, ReadOnlySpan`1 value, TypeCode type)
   at System.Number.ParseDouble(ReadOnlySpan`1 value, NumberStyles styles, NumberFormatInfo info)
   at System.Double.Parse(String s, IFormatProvider provider)
   at System.Windows.Input.MouseEventArgs.SetPointerAbsolutePosition(Object jsEventArg, Window window)
   at System.Windows.Input.MouseEventArgs.FillEventArgs(UIElement element, Object jsEventArg)
   at System.Windows.UIElement.ProcessMouseButtonEvent(Object jsEventArg, RoutedEvent routedEvent, Boolean refreshClickCount)
   at System.Windows.UIElement.ProcessOnMouseUp(Object jsEventArg)
   at System.Windows.UIElement.NativeEventCallback(UIElement mouseTarget, UIElement keyboardTarget, Object jsEventArg)
   at OpenSilver.Internal.NativeEventsManager.NativeEventCallback(Object jsEventArg)
   at OpenSilver.Internal.NativeEventsManager.<.ctor>b__4_0(Object jsEventArg)
   at System.Reflection.MethodInvoker.InterpretedInvoke(Object obj, Span`1 args, BindingFlags invokeAttr)
   --- End of inner exception stack trace ---
at System.Reflection.RuntimeMethodInfo.Invoke(Object obj, BindingFlags invokeAttr, Binder binder, Object[] parameters, CultureInfo culture)
   at System.Reflection.MethodBase.Invoke(Object obj, Object[] parameters)
   at System.Delegate.DynamicInvokeImpl(Object[] args)
   at System.MulticastDelegate.DynamicInvokeImpl(Object[] args)
   at System.Delegate.DynamicInvoke(Object[] args)
   at CSHTML5.Internal.OnCallBackImpl.DelegateDynamicInvoke(Delegate d, Object[] args)
   at CSHTML5.Internal.OnCallBackImpl.CallMethod[Object[]](Int32 callbackId, String idWhereCallbackArgsAreStored, Func`6 makeArguments, Object[] callbackArgs)
   at CSHTML5.Internal.OnCallBackImpl.<>c__DisplayClass8_0`1[[System.Object[], System.Private.CoreLib, Version=7.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]].<OnCallbackFromJavaScript>b__1()`